### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ occupancies (SO, signal bandwidth) ranging from 4.5 to 20 kHz. The corresponding
 bit rates vary from below 5 kbps to about 55 kbps. A configuration that is widely
 used is RM B (==1) and 10 kHz bandwidth (SO 3). Among other parameters, the
 station label and a text message can also be set by simply adapting the 
-correspondant blocks' values.
+correspondent blocks' values.
 
 
 (Current) Constraints


### PR DESCRIPTION
@kit-cel, I've corrected a typographical error in the documentation of the [gr-drm](https://github.com/kit-cel/gr-drm) project. Specifically, I've changed correspondant to correspondent. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.